### PR TITLE
add kaizo and duckinfclass iams

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -300,6 +300,8 @@ public:
 	virtual int GetKaizoNetworkVersion(int ClientId) { return 0; } //+KZ: identify kaizo network clients
 
 	virtual int GetClientInfclassVersion(int ClientId) { return 0; } //identify infclass clients
+	virtual bool IsKaizoClient(int ClientId) { return false; } //identify Kaizo clients
+	virtual bool IsDuckInfclassClient(int ClientId) { return false; } //identify Duck/Infclass clients
 	virtual bool IsTaterClient(int ClientId) { return false; } // identify tater clients
 	virtual bool IsQxdClient(int ClientId) { return false; } // identify qxd clients
 	virtual bool IsChillerbotClient(int ClientId) { return false; } // identify chillerbot clients

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -600,6 +600,8 @@ int CServer::Init()
 		Client.m_KaizoNetworkVersion = 0; // +KZ Kaizo Network client version
 		Client.m_InfClassVersion = 0;
 		Client.m_IsTaterClient = false; //+KZ
+		Client.m_IsKaizoClient = false;
+		Client.m_IsDuckInfclassClient = false;
 		Client.m_IsQxdClient = false;
 		Client.m_IsChillerbotClient = false;
 		Client.m_IsStAClient = false;
@@ -1155,6 +1157,8 @@ int CServer::NewClientNoAuthCallback(int ClientId, void *pUser)
 
 	pThis->m_aClients[ClientId].m_InfClassVersion = 0; //+KZ
 	pThis->m_aClients[ClientId].m_IsTaterClient = false; //+KZ
+	pThis->m_aClients[ClientId].m_IsKaizoClient = false;
+	pThis->m_aClients[ClientId].m_IsDuckInfclassClient = false;
 	pThis->m_aClients[ClientId].m_IsQxdClient = false;
 	pThis->m_aClients[ClientId].m_IsChillerbotClient = false;
 	pThis->m_aClients[ClientId].m_IsStAClient = false;
@@ -1204,6 +1208,8 @@ int CServer::NewClientCallback(int ClientId, void *pUser, bool Sixup)
 
 	pThis->m_aClients[ClientId].m_InfClassVersion = 0; //+KZ
 	pThis->m_aClients[ClientId].m_IsTaterClient = false; //+KZ
+	pThis->m_aClients[ClientId].m_IsKaizoClient = false;
+	pThis->m_aClients[ClientId].m_IsDuckInfclassClient = false;
 	pThis->m_aClients[ClientId].m_IsQxdClient = false;
 	pThis->m_aClients[ClientId].m_IsChillerbotClient = false;
 	pThis->m_aClients[ClientId].m_IsStAClient = false;
@@ -1779,6 +1785,14 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				}
 				m_aClients[ClientId].m_InfClassVersion = InfClassVersion;
 			}
+		}
+		else if(Msg == NETMSG_IAM_KAIZO_CLIENT)
+		{
+			m_aClients[ClientId].m_IsKaizoClient = true;
+		}
+		else if(Msg == NETMSG_IAM_DUCKCLIENT)
+		{
+			m_aClients[ClientId].m_IsDuckInfclassClient = true;
 		}
 		else if(Msg == NETMSG_IAMTATER)
 		{
@@ -4641,6 +4655,8 @@ bool CServer::SetTimedOut(int ClientId, int OrigId)
 	//Other Clients
 	m_aClients[ClientId].m_InfClassVersion = m_aClients[OrigId].m_InfClassVersion;
 	m_aClients[ClientId].m_IsTaterClient = m_aClients[OrigId].m_IsTaterClient;
+	m_aClients[ClientId].m_IsKaizoClient = m_aClients[OrigId].m_IsKaizoClient;
+	m_aClients[ClientId].m_IsDuckInfclassClient = m_aClients[OrigId].m_IsDuckInfclassClient;
 	m_aClients[ClientId].m_IsQxdClient = m_aClients[OrigId].m_IsQxdClient;
 	m_aClients[ClientId].m_IsChillerbotClient = m_aClients[OrigId].m_IsChillerbotClient;
 	m_aClients[ClientId].m_IsStAClient = m_aClients[OrigId].m_IsStAClient;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -92,6 +92,8 @@ class CServer : public IServer
 
 	//Other Clients
 	virtual int GetClientInfclassVersion(int ClientId) override;
+	virtual bool IsKaizoClient(int ClientId) override { return m_aClients[ClientId].m_IsKaizoClient; }
+	virtual bool IsDuckInfclassClient(int ClientId) override { return m_aClients[ClientId].m_IsDuckInfclassClient; }
 	virtual bool IsTaterClient(int ClientId) override { return m_aClients[ClientId].m_IsTaterClient; }
 	virtual bool IsQxdClient(int ClientId) override { return m_aClients[ClientId].m_IsQxdClient; }
 	virtual bool IsChillerbotClient(int ClientId) override { return m_aClients[ClientId].m_IsChillerbotClient; }
@@ -195,6 +197,8 @@ public:
 		int m_KaizoNetworkVersion; // +KZ: Kaizo Network client version
 
 		int m_InfClassVersion; // to identify infclass clients
+		bool m_IsKaizoClient; // to identify Kaizo clients
+		bool m_IsDuckInfclassClient; // to identify Duck/Infclass clients
 		bool m_IsTaterClient; // to identify tater clients
 		bool m_IsQxdClient; // to identify qxd clients
 		bool m_IsChillerbotClient; // to identify chillerbot clients

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -53,6 +53,8 @@ UUID(NETMSG_KZ_KAIZO_NETWORK_VERSION, "kaizoversion@m0rekz.github.io")
 
 //Other Clients
 UUID(NETMSG_CLIENTVER_INFCLASS, "clientver@infclass") // InfClass
+UUID(NETMSG_IAM_KAIZO_CLIENT, "i-am-kaizo-client-pluskz@m0rekz.github.io") // Kaizo Client
+UUID(NETMSG_IAM_DUCKCLIENT, "i-am-duckclient@pointer31.github.io") // DuckInfclass Client
 UUID(NETMSG_IAMTATER, "iamtater@sjrc6.github.io") // T-Client
 UUID(NETMSG_IAMQXD, "i-am-qxd@qxdFox.github.io") // E-Client
 UUID(NETMSG_IAMCHILLERBOT, "i-am-chillerbot@chillerbot.github.io") // Chillerbot-UX

--- a/src/game/server/gamecontext_kz.cpp
+++ b/src/game/server/gamecontext_kz.cpp
@@ -623,6 +623,8 @@ void CGameContext::IdentifyClientName(int ClientId, char *pName, int StrSize)
 		int KaizoNetwork = Server()->GetKaizoNetworkVersion(ClientId);
 
 		int InfClass = Server()->GetClientInfclassVersion(ClientId);
+		bool Kaizo = Server()->IsKaizoClient(ClientId);
+		bool DuckInfclass = Server()->IsDuckInfclassClient(ClientId);
 		bool Tater = Server()->IsTaterClient(ClientId);
 		bool Qxd = Server()->IsQxdClient(ClientId);
 		bool Chillerbot = Server()->IsChillerbotClient(ClientId);
@@ -635,13 +637,14 @@ void CGameContext::IdentifyClientName(int ClientId, char *pName, int StrSize)
 		bool Rushie = Server()->IsRushieClient(ClientId);
 		bool SClient = Server()->IsSClientClient(ClientId);
 
-		if(KaizoNetwork)
+		
+		if(Kaizo)
 		{
-			str_copy(aName, "Kaizo Network Client (0.6)", StrSize);
+			str_copy(aName, "Kaizo Client (0.6)", StrSize);
 		}
-		else if(InfClass)
+		else if(DuckInfclass)
 		{
-			str_copy(aName, "InfClass Client (0.6)", StrSize);
+			str_copy(aName, "Duck/Infclass Client (0.6)", StrSize);
 		}
 		else if(Tater)
 		{
@@ -686,6 +689,14 @@ void CGameContext::IdentifyClientName(int ClientId, char *pName, int StrSize)
 		else if(SClient)
 		{
 			str_copy(aName, "S-Client (0.6)", StrSize);
+		}
+		else if(KaizoNetwork)
+		{
+			str_copy(aName, "Kaizo Network Client (0.6)", StrSize);
+		}
+		else if(InfClass)
+		{
+			str_copy(aName, "InfClass Client (0.6)", StrSize);
 		}
 		else
 		{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Adds support for Kaizo and DuckInfclass IAMs, and reorders kaizo/infclass version in the showing of the client type so they are shown last (clients implementing the protocols sending their IAMs be shown as their IAMs tell the server), and finally renames kaizo client. Closes #24 and closes #21 

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions

<!-- If you did not check the AI box above, please briefly describe how AI was used (1–2 sentences). Example: "AI helped me draft initial documentation", "AI helped me translate from my native language to English" or "AI suggested refactoring options, which I reviewed and modified". -->
